### PR TITLE
adds historical transactions

### DIFF
--- a/api/controllers/historicalStatistics.js
+++ b/api/controllers/historicalStatistics.js
@@ -1,0 +1,94 @@
+import { BRIDGE_TRANSACTIONS_COLLECTION } from '../db/index.js'
+import { queryAndCache } from '../db/queryAndCache.js'
+
+async function query({ type, chainId, days = 30 }) {
+  const past_x_days = days * 86400000
+
+  let matchFilter = {
+    $match: {
+      $expr: {
+        $gt: [
+          { $toDate: '$_id' },
+          { $toDate: { $subtract: [new Date(), past_x_days] } },
+        ],
+      },
+    },
+  }
+
+  let sorter = {
+    $sort: { '_id.dateYMD': 1 },
+  }
+
+  let groupFilter = {
+    $group: {
+      _id: {
+        dateYMD: {
+          $dateFromParts: {
+            year: { $year: '$_id' },
+            month: { $month: '$_id' },
+            day: { $dayOfMonth: '$_id' },
+          },
+        },
+      },
+    },
+  }
+
+  let project = {
+    $project: {
+      _id: 0,
+      date: {
+        $dateToString: { date: '$_id.dateYMD', format: '%d-%m-%Y' },
+      },
+    },
+  }
+
+  if (type === 'BRIDGEVOLUME') {
+    groupFilter['$group']['total'] = { $sum: '$sentValueUSD' }
+    project['$project']['total'] = 1
+  } else if (type === 'TRANSACTIONS') {
+    groupFilter['$group']['total'] = { $sum: 1 }
+    project['$project']['total'] = 1
+  } else if (type === 'ADDRESSES') {
+    groupFilter['$group']['uniqueAddresses'] = { $addToSet: '$fromAddress' }
+    project['$project']['total'] = { $size: '$uniqueAddresses' }
+  }
+
+  if (chainId) {
+    matchFilter['$match']['$or'] = [
+      { fromChainId: { $eq: chainId } },
+      { toChainId: { $eq: chainId } },
+    ]
+  }
+
+  let query = await BRIDGE_TRANSACTIONS_COLLECTION.aggregate([
+    matchFilter,
+    groupFilter,
+    sorter,
+    project,
+  ]).toArray()
+
+  let dateResults = query.map((entry) => {
+    return {
+      date: entry.date,
+      total: +entry.total.toString(),
+    }
+  })
+
+  let total = dateResults.reduce((accumulator, object) => {
+    return accumulator + object.total
+  }, 0)
+
+  return {
+    type,
+    total,
+    dateResults,
+  }
+}
+
+export async function historicalStatistics(_, args) {
+  let queryName = 'historicalStatistics'
+  let expireIn = 3600
+  let res = await queryAndCache(queryName, args, query, expireIn)
+
+  return res
+}

--- a/api/gql/schema.js
+++ b/api/gql/schema.js
@@ -24,6 +24,17 @@ export const schema = gql`
     time:           Int
   }
 
+  type DateResult {
+    date:   String,
+    total:  Float
+  }
+
+  type HistoricalResult {
+    total:        Float
+    dateResults:  [DateResult]
+    type:         HistoricalResultType
+  }
+
   type ScalarResult {
     value: String
   }
@@ -68,6 +79,12 @@ export const schema = gql`
     MEDIAN
     TOTAL
     COUNT
+  }
+
+  enum HistoricalResultType {
+    BRIDGEVOLUME
+    TRANSACTIONS
+    ADDRESSES
   }
 
   type Query {
@@ -138,5 +155,14 @@ export const schema = gql`
     Returns csv of address' transactions
     """
     getCsv(address: String!): CSVData
+    
+    """
+    Historical transactional data
+    """
+    historicalStatistics(
+      chainId:  Int
+      type:     HistoricalResultType = BRIDGEVOLUME
+      days:     Int = 30
+    ): HistoricalResult
   }
 `

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import { countByChainId } from './api/controllers/countByChainId.js'
 import { countByTokenAddress } from './api/controllers/countByTokenAddress.js'
 import { addressRanking } from './api/controllers/addressRanking.js'
 import { getCsv } from './api/controllers/getCsv.js'
+import { historicalStatistics } from './api/controllers/historicalStatistics.js'
 
 // This function will create a new server Apollo Server instance
 export const createServer = async (options = { port: 4000 }) => {
@@ -26,6 +27,7 @@ export const createServer = async (options = { port: 4000 }) => {
         countByTokenAddress,
         addressRanking,
         getCsv,
+        historicalStatistics,
       },
     },
     plugins: [ApolloServerPluginLandingPageGraphQLPlayground({})],

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -207,4 +207,25 @@ describe('integration tests', () => {
     expect(responseBody).to.be.an('array').that.is.not.empty
     expect(responseBody[0].kappa).to.be.an('string')
   }).timeout(10000)
+
+  it('should query historical bridge volume', async() => {
+    let queryData = {
+      query:`
+        query {
+          historicalStatistics(type:BRIDGEVOLUME){
+            type
+            total
+            dateResults {
+              total
+              date
+            }
+          }
+        }
+      `
+    }
+    const response = await request(url).post('/').send(queryData)
+    let responseBody = response.body.data.historicalStatistics
+    expect(responseBody.type).to.eq('BRIDGEVOLUME')
+    expect(responseBody.dateResults).to.be.an('array').that.is.not.empty
+  }).timeout(10000)
 })

--- a/workers/cacheChainPage.js
+++ b/workers/cacheChainPage.js
@@ -1,10 +1,17 @@
-import {cacheBridgeTransactions, cacheCountByTokenId, cacheCountByTokenAddress, cacheTotalAndCountStatistic} from "./commonQueries.js";
+import {
+  cacheBridgeTransactions,
+  cacheCountByTokenId,
+  cacheCountByTokenAddress,
+  cacheTotalAndCountStatistic,
+  cacheHistoricalStatistics,
+} from './commonQueries.js'
 
 export async function cacheChainData(chainId) {
-    await Promise.all([
-        cacheBridgeTransactions(chainId),
-        cacheCountByTokenId(chainId),
-        cacheCountByTokenAddress(chainId),
-        cacheTotalAndCountStatistic(chainId)
-    ])
+  await Promise.all([
+    cacheBridgeTransactions(chainId),
+    cacheCountByTokenId(chainId),
+    cacheCountByTokenAddress(chainId),
+    cacheTotalAndCountStatistic(chainId),
+    cacheHistoricalStatistics(chainId),
+  ])
 }

--- a/workers/commonQueries.js
+++ b/workers/commonQueries.js
@@ -4,7 +4,7 @@ import {countByTokenAddress} from "../api/controllers/countByTokenAddress.js";
 import {countByChainId} from "../api/controllers/countByChainId.js";
 import {bridgeAmountStatistic} from "../api/controllers/bridgeAmountStatistic.js";
 import {bridgeTransactions} from "../api/controllers/bridgeTransactions.js";
-
+import { historicalStatistics } from '../api/controllers/historicalStatistics.js';
 
 export async function cacheBridgeTransactions(chainId) {
     let startTime = getCurrentTimestamp();
@@ -70,5 +70,30 @@ export async function cacheTotalAndCountStatistic(chainId = null) {
         console.log(`Finished caching front page statistic-${chainId ? chainId : ""} in ${endTime - startTime} seconds at ${endTime}`)
     } catch (err) {
         console.error(`Error in cacheTotalAndCountStatistic - ${err}`)
+    }
+}
+
+export async function cacheHistoricalStatistics(chainId = null) {
+    let bridgeVolumeArgs = { bypassCache: true, type: 'BRIDGEVOLUME' }
+    let transactionsArgs = { bypassCache: true, type: 'TRANSACTIONS' }
+    let addressesArgs = { bypassCache: true, type: 'ADDRESSES' }
+
+    if (chainId) {
+        bridgeVolumeArgs['chainId'] = chainId
+        transactionsArgs['chainId'] = chainId
+        addressesArgs['chainId'] = chainId
+    }
+
+    try {
+        let startTime = getCurrentTimestamp();
+        console.log(`Started caching historical statistics-${chainId ? chainId : ""} at ${startTime}`)
+        await historicalStatistics(null, bridgeVolumeArgs)
+        await historicalStatistics(null, transactionsArgs)
+        await historicalStatistics(null, addressesArgs)
+        let endTime = getCurrentTimestamp()
+        console.log(`Finished caching historical statitistics-${chainId ? chainId : ""} in ${endTime - startTime} seconds at ${endTime}`)
+
+    } catch (err) {
+        console.error(`Error in cacheHistoricalStatistics-${err}`)
     }
 }

--- a/workers/runWorkers.js
+++ b/workers/runWorkers.js
@@ -1,17 +1,23 @@
-import "./config.js"
+import './config.js'
 
-import {cacheCountByTokenAddress, cacheCountByTokenId, cacheTotalAndCountStatistic} from "./commonQueries.js";
-import {cacheLatestBridgeTransactions} from "./cacheFrontPage.js";
-import {cacheChainData} from "./cacheChainPage.js";
-import {ChainId} from "@synapseprotocol/sdk";
+import {
+  cacheCountByTokenAddress,
+  cacheCountByTokenId,
+  cacheTotalAndCountStatistic,
+  cacheHistoricalStatistics,
+} from './commonQueries.js'
+import { cacheLatestBridgeTransactions } from './cacheFrontPage.js'
+import { cacheChainData } from './cacheChainPage.js'
+import { ChainId } from '@synapseprotocol/sdk'
 
 // Caching data for front page
 setInterval(cacheLatestBridgeTransactions, 20 * 1000)
 setInterval(cacheCountByTokenId, 10 * 1000)
 setInterval(cacheCountByTokenAddress, 10 * 1000)
 setInterval(cacheTotalAndCountStatistic, 20 * 1000)
+setInterval(cacheHistoricalStatistics, 3600 * 1000)
 
 // Cache data for all chain pages
 for (let chainId of Object.values(ChainId)) {
-    setInterval(cacheChainData, 30 * 1000, chainId, )
+  setInterval(cacheChainData, 30 * 1000, chainId)
 }


### PR DESCRIPTION
- This PR allows us to query for historical transactions on Bridge Volume, Transactions, and Unique Addresses

Example response for bridge volume over last 30 days:

```
{
  "data": {
    "historicalStatistics": {
      "type": "BRIDGEVOLUME",
      "total": 279447314.29098177,
      "dateResults": [
        {
          "total": 2206296.061202331,
          "date": "19-06-2022"
        },
        {
          "total": 6345558.247962557,
          "date": "20-06-2022"
        },
        {
          "total": 8809216.167362723,
          "date": "21-06-2022"
        },
. . . 
```